### PR TITLE
Fix the typo of CODECOV_ATS_TESTS_TO_RUN

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cli:
 #   run: pytest ...
 ```
 
-6. Update your `pytest` run to include the tests selected from ATS. You will need to add the `CODECOV_ATS_TESTS_TO_RUN` variable like below.
+6. Update your `pytest` run to include the tests selected from ATS. You will need to add the `CODECOV_ATS_TESTS` variable like below.
 
 ```yaml
 - name: Run tests and collect coverage


### PR DESCRIPTION
Fix CODECOV_ATS_TESTS_TO_RUN to CODECOV_ATS_TESTS