### PR TITLE
change output of action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install python dependencies
         run: pip install -r app/requirements.txt
       - name: Run ATS
+        id: run_ats
         uses: ./
         with:
           folders_to_exclude: node_modules
@@ -36,12 +37,18 @@ jobs:
           CODECOV_STATIC_TOKEN: ${{ secrets.CODECOV_STATIC_TOKEN }}
       - name: "[debug] see content of generated files"
         run: |
+          echo ${{ steps.run_ats.outputs.all_tests_skipped }}
           ls codecov_ats
           cat codecov_ats/tests_to_run.txt
           cat codecov_ats/tests_to_skip.txt
       - name: Run Tests and collect coverage (if there are tests to run)
         run: |
+          if [[ "${{ steps.run_ats.outputs.all_tests_skipped }}" != 1 ]]; then
             cat codecov_ats/tests_to_run.txt | xargs pytest --cov app
+          fi
+      - name: "[debug] Running skipped tests"
+        run: |
+          cat codecov_ats/tests_to_skip.txt | xargs pytest --cov app
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4-beta
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,15 +37,12 @@ jobs:
           CODECOV_STATIC_TOKEN: ${{ secrets.CODECOV_STATIC_TOKEN }}
       - name: "[debug] see content of generated files"
         run: |
-          echo ${{ steps.run_ats.outputs.all_tests_skipped }}
           ls codecov_ats
           cat codecov_ats/tests_to_run.txt
           cat codecov_ats/tests_to_skip.txt
       - name: Run Tests and collect coverage (if there are tests to run)
         run: |
-          if [[ "${{ steps.run_ats.outputs.all_tests_skipped }}" != 1 ]]; then
             cat codecov_ats/tests_to_run.txt | xargs pytest --cov app
-          fi
       - name: "[debug] Running skipped tests"
         run: |
           cat codecov_ats/tests_to_skip.txt | xargs pytest --cov app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 defaults:
   run:
-    # the default default is:
+    # the default is:
     #      bash --noprofile --norc -eo pipefail {0}
     # Helps with debugging
     shell: bash --noprofile --norc -eo pipefail -ux {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,17 +34,14 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           CODECOV_STATIC_TOKEN: ${{ secrets.CODECOV_STATIC_TOKEN }}
+      - name: "[debug] see content of generated files"
+        run: |
+          ls codecov_ats
+          cat codecov_ats/tests_to_run.txt
+          cat codecov_ats/tests_to_skip.txt
       - name: Run Tests and collect coverage (if there are tests to run)
         run: |
-          length_of_tests=$(cat codecov_ats/tests_to_run.json | jq 'length')
-          # The 1st value doesn't count, it's '--cov-context=test' (hence -gt 1)
-          if [ $length_of_tests -gt 1 ]; then
-            echo "Running $length_of_tests tests"
-            # --raw-output0 doesn't work.
-            cat codecov_ats/tests_to_run.json | jq 'join("\u0000")' --raw-output | tr -d '\n' | xargs -r0 pytest --cov app
-          else
-            echo "No tests to run"
-          fi
+            cat codecov_ats/tests_to_run.txt | xargs pytest --cov app
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4-beta
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,17 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           CODECOV_STATIC_TOKEN: ${{ secrets.CODECOV_STATIC_TOKEN }}
-      - name: Run Tests and collect coverage
-        run: cat codecov_ats/tests_to_run.json | jq 'join("\u0000")' --raw-output | tr -d '\n' | xargs -r0 pytest --cov app
+      - name: Run Tests and collect coverage (if there are tests to run)
+        run: |
+          length_of_tests=$(cat codecov_ats/tests_to_run.json | jq 'length')
+          # The 1st value doesn't count, it's '--cov-context=test' (hence -gt 1)
+          if [ $length_of_tests -gt 1 ]; then
+            echo "Running $length_of_tests tests"
+            # --raw-output0 doesn't work.
+            cat codecov_ats/tests_to_run.json | jq 'join("\u0000")' --raw-output | tr -d '\n' | xargs -r0 pytest --cov app
+          else
+            echo "No tests to run"
+          fi
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4-beta
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,13 @@
 name: Workflow for Codecov Action
 on: [push, pull_request]
+
+defaults:
+  run:
+    # the default default is:
+    #      bash --noprofile --norc -eo pipefail {0}
+    # Helps with debugging
+    shell: bash --noprofile --norc -eo pipefail -ux {0}
+
 jobs:
   run:
     runs-on: ${{ matrix.os }}
@@ -27,7 +35,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           CODECOV_STATIC_TOKEN: ${{ secrets.CODECOV_STATIC_TOKEN }}
       - name: Run Tests and collect coverage
-        run: pytest --cov app ${{ env.CODECOV_ATS_TESTS }}
+        run: cat codecov_ats/tests_to_run.json | jq 'join("\u0000")' --raw-output | tr -d '\n' | xargs -r0 pytest --cov app
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4-beta
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 coverage
 __pycache__
 codecov_ats_local.sh
+
+# act
+.secrets

--- a/README.md
+++ b/README.md
@@ -60,21 +60,13 @@ This action will populate files in `codecov_ats` folder with the tests to run.
 ```
 
 6. Update your `pytest` run to include the tests selected from ATS. You will read the list of tests that were selected to run by ATS.
-These tests are exported to `codecov_ats/tests_to_run.json`. Skips running tests if no tests were selected.
-(You can copy the same step and use the `codecov_ats/tests_to_skip.json` file to run the tests selected to be skipped)
+These tests are exported to `codecov_ats/tests_to_run.txt`. Skips running tests if no tests were selected.
+(You can copy the same step and use the `codecov_ats/tests_to_skip.txt` file to run the tests selected to be skipped)
 
 ```yaml
 - name: Run tests and collect coverage
   run: |
-    length_of_tests=$(cat codecov_ats/tests_to_run.json | jq 'length')
-    # The 1st value doesn't count, it's '--cov-context=test' (hence -gt 1)
-    if [ $length_of_tests -gt 1 ]; then
-      echo "Running $length_of_tests tests"
-      # --raw-output0 doesn't work.
-      cat codecov_ats/tests_to_run.json | jq 'join("\u0000")' --raw-output | tr -d '\n' | xargs -r0 pytest --cov app
-    else
-      echo "No tests to run"
-    fi
+    cat codecov_ats/tests_to_run.txt | xargs pytest --cov app
 ```
 
 1. If you are not already using the Codecov CLI to upload coverage, you can update the Codecov Action to `v4-beta`

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ cli:
 ```
 
 5. Add the Codecov ATS Action to your CI. This should happen after you install python dependencies, but before you run tests.
+This action will populate files in `codecov_ats` folder with the tests to run.
 
 ```yaml
 - name: Run ATS
@@ -58,14 +59,15 @@ cli:
 #   run: pytest ...
 ```
 
-6. Update your `pytest` run to include the tests selected from ATS. You will need to add the `CODECOV_ATS_TESTS` variable like below.
+6. Update your `pytest` run to include the tests selected from ATS. You will read the list of tests that were selected to run by ATS.
+These tests are exported to `codecov_ats/tests_to_run.json`
 
 ```yaml
 - name: Run tests and collect coverage
-  run: pytest --cov app ${{ env.CODECOV_ATS_TESTS }}
+  run: cat codecov_ats/tests_to_run.json | jq 'join("\u0000")' --raw-output | tr -d '\n' | xargs -r0 pytest --cov app
 ```
 
-7. If you are not already using the Codecov CLI to upload coverage, you can update the Codecov Action to `v4-beta`
+1. If you are not already using the Codecov CLI to upload coverage, you can update the Codecov Action to `v4-beta`
 
 ```yaml
 - name: Upload coverage to Codecov
@@ -78,3 +80,10 @@ cli:
 ```
 
 8. Run your CI! On your first run, Codecov will not have any labels data and will have to run all tests. However, once all following commits or pull requests are rebased on top of this commit, you should be able to see the benefits of ATS.
+
+### Output
+
+This action creates a `codecov_ats` folder in the current directory and populates it with 3 files:
+1. `codecov_ats/tests_to_run.json` - List of tests selected by Automated Test Selection that should be executed
+2. `codecov_ats/tests_to_skip.json` - List of tests that are being skiped
+3. `codecov_ats/result.json` - Summary of results for test selection

--- a/action.yml
+++ b/action.yml
@@ -84,9 +84,8 @@ runs:
         ${{ github.action_path }}/dist/codecov_ats.sh | tee codecov_ats_output.txt
 
         if [[ $? == 0 ]]; then
-          echo "Setting CODECOV_ATS_TESTS to GitHub environment"
-          commands=$(tail -1 codecov_ats_output.txt)
-          echo "CODECOV_ATS_TESTS=$commands" >> "$GITHUB_ENV"
+          echo "Codecov: Action complete. Check codecov_ats folder for results."
+          cat codecov_ats/result.json
         else
           echo "Codecov: Action failed to successfully run"
           exit 1;

--- a/dist/codecov_ats.sh
+++ b/dist/codecov_ats.sh
@@ -140,14 +140,5 @@ tee <<< \
     "$GITHUB_STEP_SUMMARY" \
     "codecov_ats/result.json"
 
-# Export 'all_tests_skipped' variable
-if [[ "$run_count" -eq 0 ]]; then
-    # For use in other jobs
-    echo "all_tests_skipped=1" >> "$GITHUB_OUTPUT"
-else
-    # For use in other jobs
-    echo "all_tests_skipped=0" >> "$GITHUB_OUTPUT"
-fi
-
 echo "Tests to run exported to ./codecov_ats/tests_to_run.txt"
 echo "Tests to run exported to ./codecov_ats/tests_to_skip.txt"

--- a/dist/codecov_ats.sh
+++ b/dist/codecov_ats.sh
@@ -121,7 +121,9 @@ fi
 mkdir codecov_ats
 # Export tests to run and tests to skip into respective files
 jq <<< "$response" '.runner_options + .ats_tests_to_run | @json' --raw-output > codecov_ats/tests_to_run.json
+jq <<< "$response" '.runner_options + .ats_tests_to_run | @sh' --raw-output > codecov_ats/tests_to_run.txt
 jq <<< "$response" '.runner_options + .ats_tests_to_skip | @json' --raw-output > codecov_ats/tests_to_skip.json
+jq <<< "$response" '.runner_options + .ats_tests_to_skip | @sh' --raw-output > codecov_ats/tests_to_skip.txt
 
 
 # Statistics on the test selection
@@ -140,5 +142,5 @@ tee <<< \
     "$GITHUB_STEP_SUMMARY" \
     "codecov_ats/result.json"
 
-echo "Tests to run exported to ./codecov_ats/tests_to_run.json"
-echo "Tests to run exported to ./codecov_ats/tests_to_skip.json"
+echo "Tests to run exported to ./codecov_ats/tests_to_run.txt"
+echo "Tests to run exported to ./codecov_ats/tests_to_skip.txt"

--- a/dist/codecov_ats.sh
+++ b/dist/codecov_ats.sh
@@ -128,6 +128,15 @@ jq <<< "$response" '.runner_options + .ats_tests_to_skip | @sh' --raw-output > c
 testcount() { jq <<< "$response" ".$1 | length"; }
 run_count=$(testcount ats_tests_to_run)
 skip_count=$(testcount ats_tests_to_skip)
+
+# Change tests_to_run to have 1 test if no tests were selected
+# This avoids users running ALL tests if no test is selected to run
+# ⚠️ it's safer for the customer if they check test counts themselves and run tests conditionally
+if [[ "$run_count" -eq 0 ]]; then
+    say "All tests skipped. Adding random test in tests_to_run to avoid running all tests"
+    jq <<< "$response" --argjson randint $RANDOM '.runner_options + [.ats_tests_to_skip[$randint % length]] | @sh' --raw-output > codecov_ats/tests_to_run.txt
+fi
+
 # Parse any potential errors that made ATS fallback to running all tests and surface them
 ats_fallback_reason=$(jq <<< "$response" '.ats_fallback_reason')
 if [ "$ats_fallback_reason" == "null" ]; then
@@ -141,4 +150,4 @@ tee <<< \
     "codecov_ats/result.json"
 
 echo "Tests to run exported to ./codecov_ats/tests_to_run.txt"
-echo "Tests to run exported to ./codecov_ats/tests_to_skip.txt"
+echo "Tests to skip exported to ./codecov_ats/tests_to_skip.txt"

--- a/dist/codecov_ats.sh
+++ b/dist/codecov_ats.sh
@@ -120,9 +120,7 @@ fi
 # Create directory to put result files
 mkdir codecov_ats
 # Export tests to run and tests to skip into respective files
-jq <<< "$response" '.runner_options + .ats_tests_to_run | @json' --raw-output > codecov_ats/tests_to_run.json
 jq <<< "$response" '.runner_options + .ats_tests_to_run | @sh' --raw-output > codecov_ats/tests_to_run.txt
-jq <<< "$response" '.runner_options + .ats_tests_to_skip | @json' --raw-output > codecov_ats/tests_to_skip.json
 jq <<< "$response" '.runner_options + .ats_tests_to_skip | @sh' --raw-output > codecov_ats/tests_to_skip.txt
 
 
@@ -141,6 +139,15 @@ tee <<< \
     "{\"ats_success\": $ats_success, \"error\": $ats_fallback_reason, \"tests_to_run\": $run_count, \"tests_analyzed\": $((run_count+skip_count))}" \
     "$GITHUB_STEP_SUMMARY" \
     "codecov_ats/result.json"
+
+# Export 'all_tests_skipped' variable
+if [[ "$run_count" -eq 0 ]]; then
+    # For use in other jobs
+    echo "all_tests_skipped=1" >> "$GITHUB_OUTPUT"
+else
+    # For use in other jobs
+    echo "all_tests_skipped=0" >> "$GITHUB_OUTPUT"
+fi
 
 echo "Tests to run exported to ./codecov_ats/tests_to_run.txt"
 echo "Tests to run exported to ./codecov_ats/tests_to_skip.txt"

--- a/src/codecov_ats.sh
+++ b/src/codecov_ats.sh
@@ -141,5 +141,14 @@ tee <<< \
     "$GITHUB_STEP_SUMMARY" \
     "codecov_ats/result.json"
 
+# Export 'all_tests_skipped' variable
+if [[ "$run_count" -eq 0 ]]; then
+    # For use in other jobs
+    echo "all_tests_skipped=1" >> "$GITHUB_OUTPUT"
+else
+    # For use in other jobs
+    echo "all_tests_skipped=0" >> "$GITHUB_OUTPUT"
+fi
+
 echo "Tests to run exported to ./codecov_ats/tests_to_run.txt"
 echo "Tests to run exported to ./codecov_ats/tests_to_skip.txt"

--- a/src/codecov_ats.sh
+++ b/src/codecov_ats.sh
@@ -141,14 +141,5 @@ tee <<< \
     "$GITHUB_STEP_SUMMARY" \
     "codecov_ats/result.json"
 
-# Export 'all_tests_skipped' variable
-if [[ "$run_count" -eq 0 ]]; then
-    # For use in other jobs
-    echo "all_tests_skipped=1" >> "$GITHUB_OUTPUT"
-else
-    # For use in other jobs
-    echo "all_tests_skipped=0" >> "$GITHUB_OUTPUT"
-fi
-
 echo "Tests to run exported to ./codecov_ats/tests_to_run.txt"
 echo "Tests to run exported to ./codecov_ats/tests_to_skip.txt"

--- a/src/codecov_ats.sh
+++ b/src/codecov_ats.sh
@@ -117,11 +117,12 @@ fi
 
 # Post process label-analysis response
 
+
 # Create directory to put result files
 mkdir codecov_ats
 # Export tests to run and tests to skip into respective files
-jq <<< "$response" '.runner_options + .ats_tests_to_run | @json' --raw-output > codecov_ats/tests_to_run.json
-jq <<< "$response" '.runner_options + .ats_tests_to_skip | @json' --raw-output > codecov_ats/tests_to_skip.json
+jq <<< "$response" '.runner_options + .ats_tests_to_run | @sh' --raw-output > codecov_ats/tests_to_run.txt
+jq <<< "$response" '.runner_options + .ats_tests_to_skip | @sh' --raw-output > codecov_ats/tests_to_skip.txt
 
 
 # Statistics on the test selection
@@ -140,5 +141,5 @@ tee <<< \
     "$GITHUB_STEP_SUMMARY" \
     "codecov_ats/result.json"
 
-echo "Tests to run exported to ./codecov_ats/tests_to_run.json"
-echo "Tests to run exported to ./codecov_ats/tests_to_skip.json"
+echo "Tests to run exported to ./codecov_ats/tests_to_run.txt"
+echo "Tests to run exported to ./codecov_ats/tests_to_skip.txt"


### PR DESCRIPTION
Currently the action sets envvars as outputs to run tests.
This is easier for the customer, but we've seen more than a few times
users hitting Linux or GHA command size limits because of the amount
of tests to run.

To solve this problem, the present changes move the output to files
created by the action.
It requires a different - more complicated - command to run tests,
as indicated in `README.md`, but should still be doable.
And should solve the command size problem too.