### PR TITLE
fix: when running all tests, dont pass in test names

### DIFF
--- a/dist/codecov_ats.sh
+++ b/dist/codecov_ats.sh
@@ -133,6 +133,9 @@ if [[ -z $ats_tests_to_run ]]; then
     else
         ats_tests_to_run=${ats_tests_to_skip_array[ $RANDOM % ${#ats_tests_to_skip_array[@]} ]}
     fi
+elif [[ -z $ats_tests_to_skip ]]; then
+    say "$y==>$x No tests are skipped, running all"
+    ats_tests_to_run=""
 fi
 
 test_commands="$runner_options "

--- a/src/codecov_ats.sh
+++ b/src/codecov_ats.sh
@@ -133,6 +133,9 @@ if [[ -z $ats_tests_to_run ]]; then
     else
         ats_tests_to_run=${ats_tests_to_skip_array[ $RANDOM % ${#ats_tests_to_skip_array[@]} ]}
     fi
+elif [[ -z $ats_tests_to_skip ]]; then
+    say "$y==>$x No tests are skipped, running all"
+    ats_tests_to_run=""
 fi
 
 test_commands="$runner_options "


### PR DESCRIPTION
If there are no tests to skip, we should run all tests. Instead of outputting all the test names (which can be a lengthy list), let's pass in nothing. `pytest` should automatically run all tests.